### PR TITLE
에디터 정렬 상태에 따라 블록 삽입 시 정렬이 유지되도록 처리

### DIFF
--- a/src/components/Editor/EditorTools/BlockTools/Delimiter/index.ts
+++ b/src/components/Editor/EditorTools/BlockTools/Delimiter/index.ts
@@ -1,3 +1,4 @@
+import useEditorStore from "@/store/useEditorStore";
 import "./index.css";
 import {
   API,
@@ -40,11 +41,11 @@ export default class Delimiter implements BlockTool {
       active: "ce-delimiter--active",
     };
 
+    const { align } = useEditorStore.getState();
     this.data = {
       ...data,
-      align: data.align || "left",
+      align: align,
     };
-
     this._element = this.drawView();
   }
 

--- a/src/components/Editor/EditorTools/BlockTools/Emoji/index.ts
+++ b/src/components/Editor/EditorTools/BlockTools/Emoji/index.ts
@@ -1,3 +1,4 @@
+import useEditorStore from "@/store/useEditorStore";
 import "./index.css";
 import {
   API,
@@ -42,9 +43,10 @@ export default class Emoji implements BlockTool {
       active: "ce-emoji--active",
     };
 
+    const { align } = useEditorStore.getState();
     this.data = {
       ...data,
-      align: data.align || "left",
+      align: align,
     };
 
     this._element = this.drawView();

--- a/src/components/Editor/EditorTools/BlockTools/Paragraph/index.ts
+++ b/src/components/Editor/EditorTools/BlockTools/Paragraph/index.ts
@@ -15,6 +15,7 @@ import type {
   ToolConfig,
   ToolboxConfig,
 } from "@editorjs/editorjs";
+import useEditorStore from "@/store/useEditorStore";
 
 export interface ParagraphConfig extends ToolConfig {
   placeholder?: string;
@@ -78,9 +79,11 @@ export default class Paragraph {
     this._placeholder = config.placeholder
       ? config.placeholder
       : Paragraph.DEFAULT_PLACEHOLDER;
+
+    const { align } = useEditorStore.getState();
     this._data = {
-      text: data?.text ?? "",
-      align: data.align || "left",
+      ...data,
+      align: align,
     };
     this._element = null;
     this._preserveBlank = config.preserveBlank ?? false;

--- a/src/components/Editor/EditorTools/BlockTools/Place/index.ts
+++ b/src/components/Editor/EditorTools/BlockTools/Place/index.ts
@@ -1,3 +1,4 @@
+import useEditorStore from "@/store/useEditorStore";
 import "./index.css";
 import {
   API,
@@ -50,9 +51,10 @@ export default class Place implements BlockTool {
       active: "ce-place--active",
     };
 
+    const { align } = useEditorStore.getState();
     this.data = {
       ...data,
-      align: data.align || "left",
+      align: align,
     };
 
     this._element = this.drawView();


### PR DESCRIPTION
## 📝 설명
정렬 활성화 상태에서 블록 삽입 시 정렬이 적용되지 않는 문제를 수정합니다. #16 

## ✅ PR 유형
- 코드 수정

## 💻 작업 내용
### 정렬 필요 블록
- [x] 텍스트
- [x] 장소
- [x] 이모지
- [x] 구분선